### PR TITLE
fe improvements

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -25,6 +25,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.10.1",
+    "react-infinite-scroll-component": "^6.1.0",
     "react-player": "^2.12.0",
     "react-redux": "^8.0.7",
     "react-router-dom": "^6.12.1",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -36,7 +36,7 @@ const App = () => {
                       <Route path="/search" element={<SearchPage />} />
                       <Route path="/songs" element={<SongPage />} />
                       <Route path="/playlists" element={<PlaylistsPage />} />
-                      <Route path="/currentPlaylist" element={<CurrentPlaylistPage />} />
+                      <Route path="/playlists/:id" element={<CurrentPlaylistPage />} />
                     </Routes>
                   </main>
                   <footer className="general-player">

--- a/client/src/components/nav/nav.js
+++ b/client/src/components/nav/nav.js
@@ -11,6 +11,7 @@ const Navbar = () => {
     const [dynamicProfilePicture, setDynamicProfilePicture] = useState(null);
     const userId = useSelector((state) => state.login.id);
     const spotifyProfile = useSelector((state) => state.spotify.profile);
+    const currentPlaylistId = useSelector((state) => state.player.playlist.id);
 
     useEffect(() => {
         try {
@@ -53,7 +54,7 @@ const Navbar = () => {
                     <Link to="/search">Search</Link>
                 </h1>
                 <h1>
-                    <Link to="/currentPlaylist">Now Playing</Link>
+                    <Link to={`/playlists/${currentPlaylistId}`}>Now Playing</Link>
                 </h1>
             </ul>
 

--- a/client/src/components/player/PlayerReducer.js
+++ b/client/src/components/player/PlayerReducer.js
@@ -6,6 +6,7 @@ const { TYPE_SPOTIFY, TYPE_YOUTUBE, TYPE_PLAYLIST, TYPE_ALBUM, TYPE_TRACK } = re
 // id: "",
 // songs: []
 const initialState = {
+    startFromTop: true,
     playlist: {
         id: "",
         playlistName: "",
@@ -27,8 +28,10 @@ const playerSlice = createSlice({
     initialState: initialState,
     reducers: {
         setPlaylist: (state, action) => {
+            const { playlist, startFromTop } = action.payload;
             console.log(action.payload);
-            state.playlist = action.payload;
+            state.playlist = playlist;
+            state.startFromTop = startFromTop;
         },
         setCurrSongID: (state, action) => {
             console.log("\r\nChanging currSongID in playerReducer");

--- a/client/src/components/player/SongPlayer.js
+++ b/client/src/components/player/SongPlayer.js
@@ -12,6 +12,7 @@ export default function SongPlayer() {
   const dispatch = useDispatch();
 
   const playlist = useSelector(state => state.player.playlist);
+  const startFromTop = useSelector(state => state.player.startFromTop);
   const currSongID = useSelector(state => state.player.currSongID);
   const songs = playlist.songs;
 
@@ -28,11 +29,13 @@ export default function SongPlayer() {
   }, [currSongID]);
 
   useEffect(() => {
-    console.log("playlist id changed, playing song");
-    setCurrentSongIndex(0);
-    if (songs && songs.length > 0) dispatch(setCurrSongIdPlaylistPage(songs[0].songID));
-    playOnLoad.current = true;
-    shuffle.current = false;
+    if (startFromTop) {
+      console.log("playlist id changed, playing song");
+      setCurrentSongIndex(0);
+      if (songs && songs.length > 0) dispatch(setCurrSongIdPlaylistPage(songs[0].songID));
+      playOnLoad.current = true;
+      shuffle.current = false;
+    }
   }, [playlist.id]);
 
   const nextSong = () => {

--- a/client/src/pages/current playlist/components/playlistContainer.js
+++ b/client/src/pages/current playlist/components/playlistContainer.js
@@ -80,6 +80,7 @@ const PlaylistContainer = ({ id, playlistLink, playlistName, type, artistName, r
                     <TrackEntry
                         key={track.songID}
                         index={songs.findIndex(song => song.songID === track.songID)}
+                        parentPlaylist={{ id, playlistLink, playlistName, type, artistName, releaseDate, thumbnailUrl, duration, isFavorited, description, songs }}
                         {...track}
                     />
                 ))}

--- a/client/src/pages/current playlist/components/trackEntry.js
+++ b/client/src/pages/current playlist/components/trackEntry.js
@@ -9,17 +9,19 @@ import { ReactComponent as OptionsIcon } from '../../../images/options.svg';
 import PlayingIcon from "../../../images/playingWave.gif";
 import "../styles/playlistTrack.css";
 
-import {setCurrSongID} from "../../../components/player/PlayerReducer.js";
+import { setCurrSongID, setPlaylist } from "../../../components/player/PlayerReducer.js";
 import { setCurrSongIdPlaylistPage } from '../redux/currentPlaylistReducer';
 
 const { TYPE_SPOTIFY, TYPE_YOUTUBE, TYPE_PLAYLIST, TYPE_ALBUM } = require("../../../typeConstants.js");
 
 
-const TrackEntry = ({ songID, name, artist, duration, album, isFavorited, link, imageLink, releaseDate, source, index, handleDropdown = () => { } }) => {
+const TrackEntry = ({ parentPlaylist, songID, name, artist, duration, album, isFavorited, link, imageLink, releaseDate, source, index, handleDropdown = () => { } }) => {
 
     const dispatch = useDispatch();
     const currSongID = useSelector(state => state.currentPlaylistPage.currSongID);
+    const currPlayingPlaylistID = useSelector(state => state.player.playlist.id);
     const trackDuration = convertMsToDuration(duration);
+    const [inPlaylistTransition, setInPlaylistTransition] = useState(false);
 
     function convertMsToDuration(duration) {
         if (typeof (duration) === 'number') {
@@ -28,13 +30,22 @@ const TrackEntry = ({ songID, name, artist, duration, album, isFavorited, link, 
     }
 
     useEffect(() => {
-        if (currSongID && currSongID.songID === songID) {
-            // highlight the current track object
+        console.log(inPlaylistTransition);
+        if (inPlaylistTransition) {
+            console.log(`song id after is ${songID}`)
+            dispatch(setCurrSongID(songID));
+            dispatch(setCurrSongIdPlaylistPage(songID));
+            setInPlaylistTransition(false);
         }
-    }, [currSongID]);
+    }, [currPlayingPlaylistID]);
 
     const handlePlay = () => {
         // Handle play button click
+        if (currPlayingPlaylistID !== parentPlaylist.id) {
+            console.log(`song id before is ${songID}`)
+            setInPlaylistTransition(true);
+            dispatch(setPlaylist({ playlist: parentPlaylist, startFromTop: false }));
+        }
         dispatch(setCurrSongID(songID));
         dispatch(setCurrSongIdPlaylistPage(songID));
     };

--- a/client/src/pages/current playlist/components/trackEntry.js
+++ b/client/src/pages/current playlist/components/trackEntry.js
@@ -30,7 +30,6 @@ const TrackEntry = ({ parentPlaylist, songID, name, artist, duration, album, isF
     }
 
     useEffect(() => {
-        console.log(inPlaylistTransition);
         if (inPlaylistTransition) {
             console.log(`song id after is ${songID}`)
             dispatch(setCurrSongID(songID));

--- a/client/src/pages/current playlist/currentPlaylistPage.js
+++ b/client/src/pages/current playlist/currentPlaylistPage.js
@@ -1,22 +1,38 @@
-
-import React, { useState, useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
 import './styles/playlistPage.css';
 
 import PlaylistContainer from "./components/playlistContainer.js";
 
 const CurrentPlaylistPage = () => {
+    const { id } = useParams();
 
-    // const currentPlaylist = useSelector(state => state.currentPlaylistPage.playlist);
-    const currentPlaylist = useSelector(state => state.player.playlist);
-    
-    const dispatch = useDispatch();
+    // this is needed for current playlist page for single song
+    const foundPlaylist = useSelector(state => state.playlists.playlists.find(p => id === p.playlistID));
+    const currentlyPlaying = useSelector(state => state.player.playlist);
+    let playlist;
+    if (!foundPlaylist) {
+        playlist = currentlyPlaying;
+    } else {
+        playlist = {
+            id: foundPlaylist.playlistID ?? foundPlaylist.originId,
+            playlistName: foundPlaylist.name,
+            thumbnailUrl: foundPlaylist.coverImageURL,
+            releaseDate: foundPlaylist.dateCreated,
+            duration: foundPlaylist.songs.length,
+            artistName: foundPlaylist.author,
+            isFavorited: foundPlaylist.isFavorited,
+            source: foundPlaylist.source,
+            type: foundPlaylist.type,
+            description: foundPlaylist.description,
+            songs: foundPlaylist.songs,
+        };
+    }
 
     return (
         <div>
             <PlaylistContainer
-                {...currentPlaylist}
+                {...playlist}
             />
         </div>
     );

--- a/client/src/pages/search/components/Options2.js
+++ b/client/src/pages/search/components/Options2.js
@@ -4,9 +4,9 @@ import '../styles/Options2.css';
 const Options2 = ({ open, top, left, deleteOnClick, editOnClick, isFavorited, handleSetFavorite }) => {
   return (
     <div className={`options-container ${open ? "active" : "inactive"}`} style={{ top: top, left: left }}>
-        <div className="options-item" onClick={handleSetFavorite}>{isFavorited ? "Unfavorite" : "Favorite"}</div>
-        <div className="options-item" onClick={editOnClick}>Edit</div>
-        <div className="options-item" onClick={deleteOnClick}>Delete</div>
+        <div className="options-item" onClick={(e) => { e.preventDefault(); handleSetFavorite(); }}>{isFavorited ? "Unfavorite" : "Favorite"}</div>
+        <div className="options-item" onClick={(e) => { e.preventDefault(); editOnClick(); }}>Edit</div>
+        <div className="options-item" onClick={(e) => { e.preventDefault(); deleteOnClick(); }}>Delete</div>
     </div>
   );
 }

--- a/client/src/pages/search/components/PlaylistResult.js
+++ b/client/src/pages/search/components/PlaylistResult.js
@@ -51,17 +51,20 @@ const PlaylistResult = ({className, songs = [], deleteOnClick, editOnClick, save
     if (isLoading && songs.length) {
       setIsLoading(false);
       dispatch(setPlaylist({
-        id: (playlistObject.playlistID)? playlistObject.playlistID: playlistObject.originId,
-        playlistName: playlistObject.name,
-        thumbnailUrl: playlistObject.coverImageURL,
-        releaseDate: playlistObject.dateCreated, //
-        duration: songs.length,
-        artistName: playlistObject.author,
-        isFavorited: playlistObject.isFavorited,
-        source: playlistObject.source,
-        description: playlistObject.description,
-        type: playlistObject.type,
-        songs: songs
+        playlist: {
+          id: (playlistObject.playlistID)? playlistObject.playlistID: playlistObject.originId,
+          playlistName: playlistObject.name,
+          thumbnailUrl: playlistObject.coverImageURL,
+          releaseDate: playlistObject.dateCreated, //
+          duration: songs.length,
+          artistName: playlistObject.author,
+          isFavorited: playlistObject.isFavorited,
+          source: playlistObject.source,
+          description: playlistObject.description,
+          type: playlistObject.type,
+          songs: songs
+        },
+        startFromTop: true,
       }));
     }
   }, [songs]); // dep array only needs songs
@@ -88,17 +91,20 @@ const PlaylistResult = ({className, songs = [], deleteOnClick, editOnClick, save
     }
     // if songs already loaded, dispatch to player
     dispatch(setPlaylist({
-      id: (playlistObject.playlistID)? playlistObject.playlistID: playlistObject.originId,
-      playlistName: playlistObject.name,
-      thumbnailUrl: playlistObject.coverImageURL,
-      releaseDate: playlistObject.dateCreated, //
-      duration: songs.length,
-      artistName: playlistObject.author,
-      isFavorited: playlistObject.isFavorited,
-      source: playlistObject.source,
-      description: playlistObject.description,
-      type: playlistObject.type,
-      songs: songs
+      playlist: {
+        id: (playlistObject.playlistID)? playlistObject.playlistID: playlistObject.originId,
+        playlistName: playlistObject.name,
+        thumbnailUrl: playlistObject.coverImageURL,
+        releaseDate: playlistObject.dateCreated, //
+        duration: songs.length,
+        artistName: playlistObject.author,
+        isFavorited: playlistObject.isFavorited,
+        source: playlistObject.source,
+        description: playlistObject.description,
+        type: playlistObject.type,
+        songs: songs
+      },
+      startFromTop: true,
     }));
   };
 
@@ -148,7 +154,7 @@ const PlaylistResult = ({className, songs = [], deleteOnClick, editOnClick, save
         <div className='essential-info'>
           <div className="thumbnail-container">
             <img className="thumbnail" src={playlistObject.coverImageURL?  playlistObject.coverImageURL: thumbnailImage} alt="Album Thumbnail" />
-            <PlayIcon className="play-icon" onClick={handlePlay} />
+            <PlayIcon className="play-icon" onClick={(e) => { e.preventDefault(); handlePlay() }} />
           </div>
           <div className="details">
             <div className="name">{playlistObject.name}</div>
@@ -157,7 +163,7 @@ const PlaylistResult = ({className, songs = [], deleteOnClick, editOnClick, save
         </div>
         <div className="stats">
           <div ref={optionsPopupRef}>
-            <OptionsIcon className="options-icon" onClick={handleOptions} ref={el => optionsRef = el} />
+            <OptionsIcon className="options-icon" onClick={(e) => { e.preventDefault(); handleOptions(); }} ref={el => optionsRef = el} />
             {optionType === OPTIONS_TYPE2 && <Options2 open={optionsOpen} top={optionsTop} left={optionsLeft} deleteOnClick={handleDelete} editOnClick={handleEdit} isFavorited={playlistObject.isFavorited} handleSetFavorite={handleSetFavorite}/>}
             {optionType === OPTIONS_TYPE3 && <Options3 open={optionsOpen} top={optionsTop} left={optionsLeft} playlistLink={(playlistObject.playlistID)? playlistObject.playlistID: playlistObject.originId} playlistType={playlistObject.type} source={playlistObject.source} saveOnClick={saveOnClick} />}
           </div>

--- a/client/src/pages/search/components/SongResult.js
+++ b/client/src/pages/search/components/SongResult.js
@@ -26,18 +26,21 @@ const SongResult = ({ className,  isFavorited, handleAddClick = () => { }, songO
 
   const handlePlay = () => {
 
-    dispatch(setPlaylist({
-      id: uuid(),
-      playlistName: songObject.name,
-      thumbnailUrl: songObject.imageLink,
-      releaseDate: songObject.releaseDate,
-      duration: songObject.duration,
-      artistName: songObject.artist,
-      isFavorited: isFavorited,
-      source: songObject.source,
-      description: null,
-      type: TYPE_TRACK,
-      songs: [songObject]
+    dispatch(setPlaylist({ 
+      playlist: {
+        id: uuid(),
+        playlistName: songObject.name,
+        thumbnailUrl: songObject.imageLink,
+        releaseDate: songObject.releaseDate,
+        duration: songObject.duration,
+        artistName: songObject.artist,
+        isFavorited: isFavorited,
+        source: songObject.source,
+        description: null,
+        type: TYPE_TRACK,
+        songs: [songObject]
+      },
+      startFromTop: true,
     }));
     // Handle play button click
   };

--- a/client/src/styles/PlaylistsPage.css
+++ b/client/src/styles/PlaylistsPage.css
@@ -98,3 +98,8 @@
   justify-content: center;
   flex-direction: column;
 }
+
+.filter-button[data-selected="true"] {
+  background-color: var(--text-base);
+  color: var(--decorative-subdued);
+}

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8581,6 +8581,13 @@ react-icons@^4.10.1:
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.10.1.tgz#3f3b5eec1f63c1796f6a26174a1091ca6437a500"
   integrity sha512-/ngzDP/77tlCfqthiiGNZeYFACw85fUjZtLbedmJ5DTlNDIwETxhwBzdOJ21zj4iJdvc0J3y7yOsX3PpxAJzrw==
 
+react-infinite-scroll-component@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-infinite-scroll-component/-/react-infinite-scroll-component-6.1.0.tgz#7e511e7aa0f728ac3e51f64a38a6079ac522407f"
+  integrity sha512-SQu5nCqy8DxQWpnUVLx7V7b7LcA37aM7tvoWjTLZp1dk6EJibM5/4EJKzOnl07/BsM1Y40sKLuqjCwwH/xV0TQ==
+  dependencies:
+    throttle-debounce "^2.1.0"
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
@@ -9829,6 +9836,11 @@ throat@^6.0.1:
   version "6.0.2"
   resolved "https://registry.npmjs.org/throat/-/throat-6.0.2.tgz"
   integrity sha512-WKexMoJj3vEuK0yFEapj8y64V0A6xcuPuK9Gt1d0R+dzCSJc0lHqQytAbSB4cDAK0dWh4T0E2ETkoLE2WZ41OQ==
+
+throttle-debounce@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.3.0.tgz#fd31865e66502071e411817e241465b3e9c372e2"
+  integrity sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ==
 
 "through@>=2.2.7 <3":
   version "2.3.8"

--- a/server/app.js
+++ b/server/app.js
@@ -3,14 +3,15 @@ var path = require('path');
 var cookieParser = require('cookie-parser');
 var logger = require('morgan');
 var cors = require('cors');
-const { DATABASE_NAME, PLAYLIST_COLLECTION } = require('./shared/mongoConstants');
+const { DATABASE_NAME, PLAYLIST_COLLECTION, PLAYLIST_COLLECTION_TEST } = require('./shared/mongoConstants');
+const { v4: uuid } = require('uuid');
 
 var indexRouter = require('./routes/index');
 var loginRouter = require('./routes/login');
 var registerRouter = require('./routes/register');
 var playlistsRouter = require('./routes/playlists');
 
-const { MongoClient } = require("mongodb");
+const { MongoClient, ObjectId } = require("mongodb");
 require('dotenv').config();
 
 const client = new MongoClient(process.env.MONGO_URI);
@@ -20,11 +21,6 @@ async function setupCollections() {
     const database = client.db(DATABASE_NAME);
     const collections = await database.listCollections().toArray();
     const collectionNames = collections.map(c => c.name);
-
-    if (collectionNames.includes(PLAYLIST_COLLECTION)) {
-      console.log(`collection ${PLAYLIST_COLLECTION} exists`);
-      return;
-    };
 
     const validator = {
       $or: [
@@ -134,10 +130,62 @@ async function setupCollections() {
       },
     };
 
-    await database.createCollection(PLAYLIST_COLLECTION, {
-      validator,
-    });
-    console.log(`collection ${PLAYLIST_COLLECTION} exists`);
+    if (collectionNames.includes(PLAYLIST_COLLECTION)) {
+      console.log(`collection ${PLAYLIST_COLLECTION} exists`);
+    } else {
+      await database.createCollection(PLAYLIST_COLLECTION, {
+        validator,
+      });
+      console.log(`collection ${PLAYLIST_COLLECTION} exists`);
+    }
+
+    // insert test data
+    if (false) {
+
+      // delete your playlists
+      const playlistTestCol = database.collection(PLAYLIST_COLLECTION_TEST);
+      // put your user id here
+      const delRes = await playlistTestCol.deleteMany({ author: new ObjectId('64b23ae964a775d33d53d832')});
+      console.log(`deleted ${delRes.deletedCount}`);
+
+      // generate new playlists
+      const docs = [];
+      for (let i = 0; i < 100; i++) {
+        docs.push({
+          artist: 'Spotify',
+          playlistID: i.toString(),
+          dateCreated: new Date(),
+          description: '...',
+          name: 'Otonashi',
+          // put your user id here
+          author: new ObjectId('64b23ae964a775d33d53d832'),
+          isFavorited: false,
+          coverImageURL: 'https://i.scdn.co/image/ab67616d0000b27304a31825fa7261e702f17f7d',
+          songs: [
+            {
+              songID: uuid(),
+              artist: 'SHOW-GO',
+              name: 'Otonashi',
+              type: 'spotify',
+              link: 'spotify:track:3W8gOphVnFTHFiE22pO08y',
+              imageLink: 'https://i.scdn.co/image/ab67616d0000b27304a31825fa7261e702f17f7d',
+              album: 'Otonashi',
+              duration: 197730,
+              releaseDate: '2022-08-26'
+            }
+          ],
+          originSpotifyId: '7AtfIT67WGJMOoCfFeoqgr',
+          isAlbum: true
+        })
+
+      }
+
+      const res = await playlistTestCol.insertMany(docs);
+
+      if (res.insertedCount) {
+        console.log(`inserted ${res.insertedCount} items`);
+      }
+    }
   } finally {
     // Ensures that the client will close when you finish/error
     await client.close();

--- a/server/routes/playlists.js
+++ b/server/routes/playlists.js
@@ -176,7 +176,7 @@ playlistsRouter.get('/', async (req, res, next) => {
       .find(query)
       .sort(sortField, sortDir) // TODO: sorting by sort field should revert the cursor to start. add $gt for the sort field, id is just default.
       .project(isDeep ? {} : { songs: 0 })
-      .limit(1) // TODO: set proper limit
+      .limit(5) // TODO: set proper limit
       .toArray();
     if (!isDeep) page.forEach(p => p.songs = []);
     return res


### PR DESCRIPTION
playlists page
- refactor filters on playlists page 
- favorited is now a filter
- filter button highlights
- infinite scroll on playlists page

playlist page
- click on any playlist in playlists page to view the single playlist page, even if not playing
- click play on any song in any playlist to switch to that playlist, at that song position
- clicking play on a playlist card should still restart at the first song

misc
- added some harness code in app.js for inserting a ton of playlists, was for testing infinite scroll. not necessary to test