### PR TITLE
options fixes

### DIFF
--- a/client/src/pages/search/components/Options3.js
+++ b/client/src/pages/search/components/Options3.js
@@ -1,7 +1,7 @@
 import React from "react";
 import '../styles/Options2.css';
 
-const Options3 = ({ open, top, left, playlistLink, playlistType, source, saveOnClick }) => {
+const Options3 = ({ open, top, left, playlistLink, playlistType, source, saveOnClick, close }) => {
 
   function handleClick() {
     saveOnClick(playlistLink, playlistType, source);
@@ -9,7 +9,7 @@ const Options3 = ({ open, top, left, playlistLink, playlistType, source, saveOnC
 
   return (
     <div className={`options-container ${open ? "active" : "inactive"}`} style={{ top: top, left: left }}>
-      <div className="options-item" onClick={handleClick}>Save to library</div>
+      <div className="options-item" onClick={(e) => { e.preventDefault(); close(); handleClick(); }}>Save to library</div>
     </div>
   );
 }

--- a/client/src/pages/search/components/PlaylistResult.js
+++ b/client/src/pages/search/components/PlaylistResult.js
@@ -167,7 +167,7 @@ const PlaylistResult = ({className, songs = [], deleteOnClick, editOnClick, save
             {(optionType === OPTIONS_TYPE2) ? 
             <Options2 open={optionsOpen} top={optionsTop} left={optionsLeft} deleteOnClick={handleDelete} editOnClick={handleEdit} isFavorited={playlistObject.isFavorited} handleSetFavorite={handleSetFavorite}/>
             :
-            <Options3 open={optionsOpen} top={optionsTop} left={optionsLeft} playlistLink={(playlistObject.playlistID)? playlistObject.playlistID: playlistObject.originId} playlistType={playlistObject.type} source={playlistObject.source} saveOnClick={saveOnClick} />}
+            <Options3 close={() => setOptionsOpen(false) } open={optionsOpen} top={optionsTop} left={optionsLeft} playlistLink={(playlistObject.playlistID)? playlistObject.playlistID: playlistObject.originId} playlistType={playlistObject.type} source={playlistObject.source} saveOnClick={saveOnClick} />}
           </div>
         </div>
         {/* {sourceIcon(playlistObject.source)} */}


### PR DESCRIPTION
- close options3 after clicking on 'add to library'
- stop click event from reaching the playlist card after clicking on 'add to library' (previously it was redirecting to the playlist page because the click event reached the card)