### PR TITLE
prevent initial fetch when redux has data

### DIFF
--- a/client/src/pages/playlists/playlistsPage.js
+++ b/client/src/pages/playlists/playlistsPage.js
@@ -25,6 +25,7 @@ const PlaylistPage = () => {
   const [editVisible, setEditVisible] = useState(false);
   const [playlistToEdit, setPlaylistToEdit] = useState(false);
   const initialFetched = useRef(false);
+  const [initialFetchDone, setInitialFetchDone] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const playlists = useSelector(state => state.playlists.playlists);
   const dispatch = useDispatch();
@@ -57,11 +58,15 @@ const PlaylistPage = () => {
       if (!initialFetched.current) {
         for (let i = 0; i < 5; i++) {
           await dispatch(getPlaylistsAsync({ isDeep: i === 0 ? true : false })).unwrap();
+          setInitialFetchDone(true); // just triggers rerender
         }
       }
     }
-    fetchData();
-
+    if (!playlists.length) {
+      fetchData();
+    } else {
+      setInitialFetchDone(true); // just triggers rerender
+    }
     return () => initialFetched.current = true
   }, []);
 


### PR DESCRIPTION
- when first loading library page, should see 5 GET playlists fired off
- if there's more pages when scrolling down, should see more GET requests fired off
- go to other page and then back to library page, no requests should be fired. all playlists should still be visible.
- nothing should break